### PR TITLE
Update homepage strategy session CTA

### DIFF
--- a/assets/css/custom/02-base-navigation.css
+++ b/assets/css/custom/02-base-navigation.css
@@ -83,6 +83,123 @@ a:hover,
   filter: brightness(0.1);
 }
 
+@media (width <= 768px) {
+  .navigation .container {
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
+  }
+
+  .navigation .navbar {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding-bottom: 0.38rem;
+    padding-top: 0.38rem;
+  }
+
+  .navigation .navbar-brand {
+    font-family: "EB Garamond", serif;
+    font-size: 1.18rem;
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+    margin-right: 0.5rem;
+    max-width: calc(100% - 52px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: none;
+    white-space: nowrap;
+  }
+
+  .navigation .navbar-collapse {
+    flex-basis: 100%;
+    padding-top: 0.4rem;
+  }
+
+  .navigation .navbar-collapse.show {
+    padding-top: 0.6rem;
+  }
+
+  .navigation .navbar:has(.navbar-collapse.show) .navbar-brand {
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+  }
+
+  .navigation .navbar-toggler {
+    align-items: center;
+    background: transparent !important;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none !important;
+    display: inline-flex;
+    height: 32px;
+    justify-content: center;
+    margin-left: auto;
+    padding: 0;
+    width: 32px;
+  }
+
+  .navigation .navbar-toggler:focus,
+  .navigation .navbar-toggler:hover,
+  .navigation .navbar-toggler:not(:disabled):not(.disabled):active {
+    background: transparent !important;
+    border: 0;
+    box-shadow: none !important;
+    outline: none;
+  }
+
+  .navigation .navbar-toggler-icon {
+    background-image: linear-gradient(
+      to bottom,
+      transparent 1px,
+      rgb(17 17 17 / 85%) 1px,
+      rgb(17 17 17 / 85%) 2px,
+      transparent 2px,
+      transparent 7px,
+      rgb(17 17 17 / 85%) 7px,
+      rgb(17 17 17 / 85%) 8px,
+      transparent 8px,
+      transparent 13px,
+      rgb(17 17 17 / 85%) 13px,
+      rgb(17 17 17 / 85%) 14px,
+      transparent 14px
+    ) !important;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 18px 16px;
+    filter: none;
+    height: 16px;
+    width: 18px;
+  }
+
+  .navigation .navbar-collapse .navbar-nav {
+    text-align: center;
+    width: 100%;
+  }
+
+  .navigation .navbar-collapse .navbar-nav .nav-item {
+    width: 100%;
+  }
+
+  .navigation .navbar-collapse .navbar-nav .nav-link {
+    display: inline-block;
+    font-family: Inter, sans-serif;
+    font-size: 1.2rem;
+    font-weight: 500 !important;
+    letter-spacing: 0.01em;
+    padding: 0.7rem 0;
+    text-transform: none;
+  }
+
+  .navigation .navbar-collapse .navbar-nav .nav-item:last-child .nav-link {
+    border: 1px solid var(--text-base);
+    border-radius: 4px;
+    margin-top: 0.5rem;
+    padding: 0.62rem 1.2rem;
+  }
+}
+
 @media (width >= 992px) {
   .navigation .navbar-nav .nav-item + .nav-item {
     margin-left: 1.8rem;

--- a/assets/css/custom/02-base-navigation.css
+++ b/assets/css/custom/02-base-navigation.css
@@ -96,6 +96,7 @@ a:hover,
     justify-content: space-between;
     padding-bottom: 0.38rem;
     padding-top: 0.38rem;
+    position: relative;
   }
 
   .navigation .navbar-brand {
@@ -117,13 +118,21 @@ a:hover,
   }
 
   .navigation .navbar-collapse.show {
-    padding-top: 0.6rem;
+    background: var(--surface-base);
+    border-top: 0;
+    box-shadow: none;
+    background: var(--surface-base);
+    display: block !important;
+    margin-top: 0;
+    padding: 0.7rem 0.9rem 0.95rem;
+    position: static;
+    width: 100%;
   }
 
   .navigation .navbar:has(.navbar-collapse.show) .navbar-brand {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
+    max-width: calc(100% - 52px);
+    opacity: 1 !important;
+    visibility: visible;
   }
 
   .navigation .navbar-toggler {
@@ -137,7 +146,9 @@ a:hover,
     justify-content: center;
     margin-left: auto;
     padding: 0;
+    position: relative;
     width: 32px;
+    z-index: 1100;
   }
 
   .navigation .navbar-toggler:focus,
@@ -174,29 +185,29 @@ a:hover,
   }
 
   .navigation .navbar-collapse .navbar-nav {
+    margin: 0 auto !important;
     text-align: center;
     width: 100%;
   }
 
   .navigation .navbar-collapse .navbar-nav .nav-item {
+    margin-bottom: 0.85rem;
     width: 100%;
   }
 
   .navigation .navbar-collapse .navbar-nav .nav-link {
-    display: inline-block;
+    display: block;
     font-family: Inter, sans-serif;
-    font-size: 1.2rem;
+    font-size: 0.7rem;
     font-weight: 500 !important;
-    letter-spacing: 0.01em;
-    padding: 0.7rem 0;
-    text-transform: none;
+    letter-spacing: 0.1em;
+    line-height: 1.2;
+    padding: 0.36rem 0;
+    text-transform: uppercase;
   }
 
-  .navigation .navbar-collapse .navbar-nav .nav-item:last-child .nav-link {
-    border: 1px solid var(--text-base);
-    border-radius: 4px;
-    margin-top: 0.5rem;
-    padding: 0.62rem 1.2rem;
+  .navigation .navbar-collapse .navbar-nav .nav-item:last-child {
+    margin-bottom: 0.85rem;
   }
 }
 

--- a/assets/css/custom/10-home.css
+++ b/assets/css/custom/10-home.css
@@ -45,6 +45,10 @@
   min-height: 360px;
 }
 
+.post-block .content p {
+  font-family: "EB Garamond", serif;
+}
+
 .section {
   padding: 50px 0 0;
 }

--- a/assets/css/custom/20-article-core.css
+++ b/assets/css/custom/20-article-core.css
@@ -30,14 +30,31 @@
   }
 }
 
+.post-single-content,
+.post-content,
+.article-body {
+  margin: 0 auto;
+  max-width: 750px;
+}
+
 .post-single-content p,
-ul,
-a,
-.list-inline-item {
+.post-single-content ul,
+.post-single-content ol,
+.post-single-content li,
+.post-single-content a,
+.post-content p,
+.post-content ul,
+.post-content ol,
+.post-content li,
+.article-body p,
+.article-body ul,
+.article-body ol,
+.article-body li {
+  font-family: "EB Garamond", serif;
   font-optical-sizing: auto;
-  font-size: 1.3rem;
+  font-size: 1.18rem;
   font-style: normal;
-  line-height: 1.7;
+  line-height: 1.75;
 }
 
 .post-single-author,
@@ -96,6 +113,22 @@ a,
   font-weight: 700;
   letter-spacing: -0.02em;
   margin-bottom: 1rem;
+  margin-top: 3rem;
+}
+
+.post-single-content h1,
+.post-single-content h2,
+.post-single-content h3,
+.post-single-content h4,
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4,
+.article-body h1,
+.article-body h2,
+.article-body h3,
+.article-body h4 {
+  font-family: "EB Garamond", serif;
   margin-top: 3rem;
 }
 

--- a/assets/css/custom/21-article-hero-meta.css
+++ b/assets/css/custom/21-article-hero-meta.css
@@ -131,3 +131,16 @@
   box-shadow: none !important;
   text-decoration: none !important;
 }
+
+@media (width <= 768px) {
+  .article-meta .share-icons,
+  .article-meta .social-share {
+    text-align: center;
+    width: 100%;
+  }
+
+  .article-meta .resp-sharing-button__link {
+    margin-left: 0.25em;
+    margin-right: 0.25em;
+  }
+}

--- a/assets/css/custom/22-article-author-related.css
+++ b/assets/css/custom/22-article-author-related.css
@@ -99,17 +99,18 @@
 }
 
 .more-like-this .section-title {
-  color: var(--text-base);
+  color: var(--text-muted);
   font-family: Inter, sans-serif;
   font-size: 0.9rem;
   font-weight: 600;
   letter-spacing: 0.06em;
   margin-bottom: 1.5em;
+  opacity: 0.9;
   text-transform: uppercase;
 }
 
 .related-article-item {
-  margin-bottom: 2em;
+  margin-bottom: 2.6em;
 }
 
 .related-article-item h4 {
@@ -135,10 +136,19 @@
 }
 
 .related-article-item p {
-  color: var(--text-inkwashed);
-  font-family: Inter, sans-serif;
-  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-family: "EB Garamond", serif;
+  font-size: 1rem;
   letter-spacing: 0.02em;
-  margin-top: 0.25em;
+  line-height: 1.45;
+  margin-top: 0.35em;
   text-transform: none !important;
+}
+
+@media (width <= 768px) {
+  .related-article-item p {
+    font-family: "EB Garamond", serif;
+    font-size: 1rem;
+    text-transform: none !important;
+  }
 }

--- a/assets/css/custom/22-article-author-related.css
+++ b/assets/css/custom/22-article-author-related.css
@@ -137,8 +137,8 @@
 .related-article-item p {
   color: var(--text-inkwashed);
   font-family: Inter, sans-serif;
-  font-size: 0.82rem;
+  font-size: 0.9rem;
   letter-spacing: 0.02em;
   margin-top: 0.25em;
-  text-transform: uppercase;
+  text-transform: none !important;
 }

--- a/assets/css/custom/22-article-author-related.css
+++ b/assets/css/custom/22-article-author-related.css
@@ -27,12 +27,12 @@
 
 .author-name {
   color: var(--text-base);
-  font-family: Inter, sans-serif;
-  font-size: 0.82rem;
+  font-family: "EB Garamond", serif;
+  font-size: 1.35rem;
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: -0.01em;
   margin: 0 0 0.25em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .author-bio {

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -13,13 +13,16 @@
 
 .strategy-session-hero {
   border-bottom: 1px solid rgb(17 17 17 / 12%);
-  margin-bottom: 3rem;
+  margin-bottom: 3.5rem;
   padding-bottom: 3rem;
 }
 
 .strategy-session-hero h1,
 .strategy-session-content h2,
-.strategy-session-content p {
+.strategy-session-content p,
+.strategy-session-content li,
+.strategy-session-format h3,
+.strategy-session-format p {
   font-family: "EB Garamond", serif;
 }
 
@@ -30,11 +33,27 @@
   margin: 0;
 }
 
-.strategy-session-intro {
+.strategy-session-subtitle {
   color: rgb(17 17 17 / 82%);
-  font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
   line-height: 1.5;
   margin: 1.5rem 0 0;
+  max-width: 42rem;
+}
+
+.strategy-session-content {
+  display: grid;
+  gap: 2rem;
+}
+
+.strategy-session-block {
+  padding: 0;
+}
+
+.strategy-session-block--business {
+  background: #f4f3f1;
+  border: 1px solid rgb(17 17 17 / 8%);
+  padding: 2rem;
 }
 
 .strategy-session-content h2 {
@@ -43,19 +62,47 @@
   margin: 0 0 1rem;
 }
 
-.strategy-session-content p {
+.strategy-session-context,
+.strategy-session-format p {
   color: rgb(17 17 17 / 82%);
   font-size: clamp(1.25rem, 2vw, 1.55rem);
   line-height: 1.6;
   margin: 0;
 }
 
-.strategy-session-content > h2 + p {
-  margin-bottom: 1.75rem;
+.strategy-session-list {
+  list-style: none;
+  margin: 1.75rem 0;
+  padding: 0;
 }
 
-.strategy-session-content > h2:not(:first-child) {
+.strategy-session-list li {
+  border-top: 1px solid rgb(17 17 17 / 10%);
+  color: rgb(17 17 17 / 82%);
+  font-size: clamp(1.15rem, 1.7vw, 1.35rem);
+  line-height: 1.55;
+  padding: 1rem 0;
+}
+
+.strategy-session-list li:last-child {
+  border-bottom: 1px solid rgb(17 17 17 / 10%);
+}
+
+.strategy-session-list__label {
+  color: #000;
+  font-weight: 700;
+}
+
+.strategy-session-format {
+  border-top: 1px solid rgb(17 17 17 / 12%);
   margin-top: 3.5rem;
+  padding-top: 2rem;
+}
+
+.strategy-session-format h3 {
+  font-size: clamp(1.7rem, 3vw, 2.15rem);
+  line-height: 1.05;
+  margin: 0 0 0.85rem;
 }
 
 .strategy-session-page .manifesto-cta {
@@ -98,6 +145,10 @@
 @media (width <= 767px) {
   .strategy-session-page {
     padding: 6rem 0 4.5rem;
+  }
+
+  .strategy-session-block--business {
+    padding: 1.4rem;
   }
 
   .strategy-session-page .power-thesis__btn {

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -1,0 +1,106 @@
+/** Section: Strategy Session **/
+.strategy-session-page {
+  background: var(--surface-base);
+  padding: 7rem 0 6rem;
+}
+
+.strategy-session-shell {
+  color: var(--text-base);
+  font-family: "EB Garamond", serif;
+  margin: 0 auto;
+  max-width: 800px;
+}
+
+.strategy-session-hero {
+  border-bottom: 1px solid rgb(17 17 17 / 12%);
+  margin-bottom: 3rem;
+  padding-bottom: 3rem;
+}
+
+.strategy-session-hero h1,
+.strategy-session-content h2,
+.strategy-session-content p {
+  font-family: "EB Garamond", serif;
+}
+
+.strategy-session-hero h1 {
+  font-size: clamp(2.6rem, 5vw, 4.3rem);
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  margin: 0;
+}
+
+.strategy-session-intro {
+  color: rgb(17 17 17 / 82%);
+  font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+  line-height: 1.5;
+  margin: 1.5rem 0 0;
+}
+
+.strategy-session-content h2 {
+  font-size: clamp(2rem, 4vw, 2.85rem);
+  line-height: 1.02;
+  margin: 0 0 1rem;
+}
+
+.strategy-session-content p {
+  color: rgb(17 17 17 / 82%);
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.strategy-session-content > h2 + p {
+  margin-bottom: 1.75rem;
+}
+
+.strategy-session-content > h2:not(:first-child) {
+  margin-top: 3.5rem;
+}
+
+.strategy-session-page .manifesto-cta {
+  margin: 0;
+}
+
+.strategy-session-page .power-thesis__btn {
+  align-items: center;
+  background: #000;
+  border: 1px solid #000;
+  border-radius: 0;
+  color: #fff;
+  display: inline-flex;
+  font-family: "EB Garamond", serif;
+  font-size: 0.95rem;
+  font-weight: 700;
+  justify-content: center;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  min-height: 56px;
+  padding: 0.95rem 1.5rem;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease;
+}
+
+.strategy-session-page .power-thesis__btn:hover,
+.strategy-session-page .power-thesis__btn:focus {
+  background: #111;
+  box-shadow: 0 12px 24px rgb(0 0 0 / 16%);
+  color: #fff;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+@media (width <= 767px) {
+  .strategy-session-page {
+    padding: 6rem 0 4.5rem;
+  }
+
+  .strategy-session-page .power-thesis__btn {
+    width: 100%;
+  }
+}

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -216,7 +216,7 @@
   transform: translateY(-2px);
 }
 
-@media (width <= 767px) {
+@media (width <= 768px) {
   .strategy-session-page {
     padding: 6rem 0 4.5rem;
   }
@@ -225,23 +225,33 @@
     align-items: start;
     gap: 2rem;
     grid-template-columns: 1fr;
+    margin-bottom: 3rem;
+    padding-bottom: 3rem;
+    text-align: center;
+  }
+
+  .strategy-session-hero__copy {
+    text-align: center;
   }
 
   .strategy-session-hero__media {
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   .strategy-session-portrait {
-    max-width: 240px;
+    border-radius: 50%;
+    margin: 2rem auto;
+    max-width: 200px;
   }
 
   .strategy-session-content {
-    gap: 2rem;
+    gap: 2.25rem;
     grid-template-columns: 1fr;
   }
 
   .strategy-session-block {
     padding: 2rem 1.25rem;
+    text-align: center;
   }
 
   .strategy-session-block--business {
@@ -252,10 +262,21 @@
     padding-top: 2rem;
   }
 
+  .strategy-session-list {
+    margin: 1.5rem 0;
+  }
+
+  .strategy-session-not-for {
+    margin-top: 3rem;
+  }
+
   .strategy-session-format {
-    line-height: 1.75;
+    line-height: 1.85;
     margin-left: auto;
     margin-right: auto;
+    margin-top: 3rem;
+    padding: 2rem;
+    text-align: center;
     width: 95%;
   }
 

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -74,8 +74,8 @@
   flex-direction: column;
   justify-content: space-between;
   min-height: 100%;
-  padding: 0 2rem 0 0;
-  transition: background-color 180ms ease;
+  padding: 3rem 2rem;
+  transition: all 0.3s ease-in-out;
 }
 
 .strategy-session-block:hover {
@@ -84,7 +84,8 @@
 
 .strategy-session-block--business {
   border-left: 1px solid #e2e8f0;
-  padding: 0 0 0 2rem;
+  margin-left: 0.5rem;
+  padding-left: 2.5rem;
 }
 
 .strategy-session-eyebrow {
@@ -183,6 +184,7 @@
 .strategy-session-page .manifesto-cta {
   margin: 0;
   padding-top: 1rem;
+  text-align: center;
 }
 
 .strategy-session-page .power-thesis__btn {
@@ -239,13 +241,22 @@
   }
 
   .strategy-session-block {
-    padding: 0;
+    padding: 2rem 1.25rem;
   }
 
   .strategy-session-block--business {
     border-left: 0;
     border-top: 1px solid #e2e8f0;
+    margin-left: 0;
+    padding-left: 1.25rem;
     padding-top: 2rem;
+  }
+
+  .strategy-session-format {
+    line-height: 1.75;
+    margin-left: auto;
+    margin-right: auto;
+    width: 95%;
   }
 
   .strategy-session-page .power-thesis__btn {

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -12,15 +12,21 @@
 }
 
 .strategy-session-hero {
+  align-items: end;
   border-bottom: 1px solid rgb(17 17 17 / 12%);
-  margin-bottom: 3.5rem;
-  padding-bottom: 3rem;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 3fr) minmax(260px, 2fr);
+  margin-bottom: 4rem;
+  padding-bottom: 3.5rem;
 }
 
 .strategy-session-hero h1,
 .strategy-session-content h2,
 .strategy-session-content p,
 .strategy-session-content li,
+.strategy-session-not-for h3,
+.strategy-session-not-for p,
 .strategy-session-format h3,
 .strategy-session-format p {
   font-family: "EB Garamond", serif;
@@ -41,19 +47,50 @@
   max-width: 42rem;
 }
 
+.strategy-session-hero__media {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.strategy-session-portrait {
+  border: 1px solid rgb(17 17 17 / 14%);
+  display: block;
+  filter: grayscale(100%) saturate(0.75) contrast(1.05);
+  height: auto;
+  max-width: 300px;
+  width: 100%;
+}
+
 .strategy-session-content {
   display: grid;
-  gap: 2rem;
+  gap: 0;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
 .strategy-session-block {
-  padding: 0;
+  background: transparent;
+  min-height: 100%;
+  padding: 0 2rem 0 0;
+  transition: background-color 180ms ease;
+}
+
+.strategy-session-block:hover {
+  background: rgb(246 242 236 / 65%);
 }
 
 .strategy-session-block--business {
-  background: #f4f3f1;
-  border: 1px solid rgb(17 17 17 / 8%);
-  padding: 2rem;
+  border-left: 1px solid #e2e8f0;
+  padding: 0 0 0 2rem;
+}
+
+.strategy-session-eyebrow {
+  color: rgb(17 17 17 / 54%);
+  font-family: Inter, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  margin: 0 0 1rem;
+  text-transform: uppercase;
 }
 
 .strategy-session-content h2 {
@@ -65,7 +102,7 @@
 .strategy-session-context,
 .strategy-session-format p {
   color: rgb(17 17 17 / 82%);
-  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  font-size: clamp(1.2rem, 1.85vw, 1.45rem);
   line-height: 1.6;
   margin: 0;
 }
@@ -79,8 +116,6 @@
 .strategy-session-list li {
   border-top: 1px solid rgb(17 17 17 / 10%);
   color: rgb(17 17 17 / 82%);
-  font-size: clamp(1.15rem, 1.7vw, 1.35rem);
-  line-height: 1.55;
   padding: 1rem 0;
 }
 
@@ -90,19 +125,60 @@
 
 .strategy-session-list__label {
   color: #000;
+  display: block;
+  font-family: "EB Garamond", serif;
+  font-size: 1.2rem;
   font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 0.25rem;
+}
+
+.strategy-session-list li span:last-child {
+  color: rgb(17 17 17 / 74%);
+  display: block;
+  font-family: Inter, sans-serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  line-height: 1.55;
+}
+
+.strategy-session-not-for {
+  margin: 4rem auto 0;
+  max-width: 34rem;
+  text-align: center;
+}
+
+.strategy-session-not-for h3 {
+  font-size: clamp(1.8rem, 3vw, 2.3rem);
+  line-height: 1.05;
+  margin: 0 0 0.85rem;
+}
+
+.strategy-session-not-for p {
+  color: rgb(17 17 17 / 72%);
+  font-size: 1.15rem;
+  line-height: 1.6;
+  margin: 0;
 }
 
 .strategy-session-format {
-  border-top: 1px solid rgb(17 17 17 / 12%);
-  margin-top: 3.5rem;
-  padding-top: 2rem;
+  border: 1px solid rgb(17 17 17 / 12%);
+  margin-top: 3rem;
+  padding: 1.5rem 1.65rem;
 }
 
 .strategy-session-format h3 {
   font-size: clamp(1.7rem, 3vw, 2.15rem);
   line-height: 1.05;
   margin: 0 0 0.85rem;
+}
+
+.strategy-session-format__note {
+  color: rgb(17 17 17 / 60%);
+  font-family: Inter, sans-serif;
+  font-size: 0.83rem;
+  letter-spacing: 0.01em;
+  margin-top: 0.9rem;
 }
 
 .strategy-session-page .manifesto-cta {
@@ -147,8 +223,33 @@
     padding: 6rem 0 4.5rem;
   }
 
+  .strategy-session-hero {
+    align-items: start;
+    gap: 2rem;
+    grid-template-columns: 1fr;
+  }
+
+  .strategy-session-hero__media {
+    justify-content: flex-start;
+  }
+
+  .strategy-session-portrait {
+    max-width: 240px;
+  }
+
+  .strategy-session-content {
+    gap: 2rem;
+    grid-template-columns: 1fr;
+  }
+
+  .strategy-session-block {
+    padding: 0;
+  }
+
   .strategy-session-block--business {
-    padding: 1.4rem;
+    border-left: 0;
+    border-top: 1px solid #e2e8f0;
+    padding-top: 2rem;
   }
 
   .strategy-session-page .power-thesis__btn {

--- a/assets/css/custom/24-strategy-session.css
+++ b/assets/css/custom/24-strategy-session.css
@@ -12,7 +12,7 @@
 }
 
 .strategy-session-hero {
-  align-items: end;
+  align-items: start;
   border-bottom: 1px solid rgb(17 17 17 / 12%);
   display: grid;
   gap: 2.5rem;
@@ -48,6 +48,7 @@
 }
 
 .strategy-session-hero__media {
+  align-self: flex-start;
   display: flex;
   justify-content: flex-end;
 }
@@ -69,6 +70,9 @@
 
 .strategy-session-block {
   background: transparent;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   min-height: 100%;
   padding: 0 2rem 0 0;
   transition: background-color 180ms ease;
@@ -84,12 +88,13 @@
 }
 
 .strategy-session-eyebrow {
-  color: rgb(17 17 17 / 54%);
+  color: var(--text-base);
   font-family: Inter, sans-serif;
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   font-weight: 600;
-  letter-spacing: 0.16em;
-  margin: 0 0 1rem;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.5rem;
+  opacity: 0.7;
   text-transform: uppercase;
 }
 
@@ -143,8 +148,10 @@
 }
 
 .strategy-session-not-for {
+  border-top: 1px solid #e2e8f0;
   margin: 4rem auto 0;
   max-width: 34rem;
+  padding-top: 2.25rem;
   text-align: center;
 }
 
@@ -173,16 +180,9 @@
   margin: 0 0 0.85rem;
 }
 
-.strategy-session-format__note {
-  color: rgb(17 17 17 / 60%);
-  font-family: Inter, sans-serif;
-  font-size: 0.83rem;
-  letter-spacing: 0.01em;
-  margin-top: 0.9rem;
-}
-
 .strategy-session-page .manifesto-cta {
   margin: 0;
+  padding-top: 1rem;
 }
 
 .strategy-session-page .power-thesis__btn {
@@ -202,20 +202,16 @@
   padding: 0.95rem 1.5rem;
   text-decoration: none;
   text-transform: uppercase;
-  transition:
-    transform 180ms ease,
-    box-shadow 180ms ease,
-    background-color 180ms ease,
-    color 180ms ease;
+  transition: all 0.3s ease-in-out;
 }
 
 .strategy-session-page .power-thesis__btn:hover,
 .strategy-session-page .power-thesis__btn:focus {
-  background: #111;
-  box-shadow: 0 12px 24px rgb(0 0 0 / 16%);
+  background: #222;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
   color: #fff;
   text-decoration: none;
-  transform: translateY(-1px);
+  transform: translateY(-2px);
 }
 
 @media (width <= 767px) {

--- a/assets/css/custom/40-footer.css
+++ b/assets/css/custom/40-footer.css
@@ -138,4 +138,10 @@
   .footer-col {
     padding: 0;
   }
+
+  .footer-brand-link {
+    align-items: center;
+    display: flex;
+    gap: 0.75rem;
+  }
 }

--- a/assets/css/custom/40-footer.css
+++ b/assets/css/custom/40-footer.css
@@ -87,9 +87,9 @@
 .footer-sub p {
   color: var(--text-base);
   font-family: Inter, sans-serif;
-  font-size: 0.9rem;
+  font-size: 0.74rem;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.14em;
   margin: 0;
   text-align: center;
   text-transform: uppercase;

--- a/assets/css/custom/40-footer.css
+++ b/assets/css/custom/40-footer.css
@@ -1,10 +1,10 @@
 /** Section: Footer Components **/
 .new-footer {
-  background-color: var(--surface-muted);
+  background-color: var(--surface-base);
   border-top: 1px solid #e2e8f0;
   color: var(--text-base);
   margin: 12em auto 0;
-  padding: 4em 2em;
+  padding: 80px 2em;
 }
 
 .footer-container {
@@ -13,26 +13,43 @@
 }
 
 .footer-main {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  padding-bottom: 2em;
+  align-items: flex-start;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: 1.2fr 1fr 1fr;
+  padding-bottom: 2.25em;
 }
 
 .footer-col {
-  padding: 1em 0;
+  min-width: 0;
+  padding: 0;
 }
 
-.footer-col.brand a {
-  font-family: "EB Garamond", serif;
-  font-size: 1.8rem;
-  font-weight: 700;
+.footer-brand-link {
+  align-items: flex-start;
+  display: inline-flex;
+  gap: 0.9rem;
   text-decoration: none;
+}
+
+.footer-avatar {
+  border-radius: 50%;
+  display: block;
+  flex: 0 0 60px;
+  height: 60px;
+  object-fit: cover;
+  width: 60px;
 }
 
 .new-footer .footer-brand-headline,
 .new-footer .footer-brand-headline:visited {
   color: var(--text-base) !important;
+  font-family: "EB Garamond", serif;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  margin-top: 0;
   text-decoration: none;
   transition: color 0.2s ease-out;
 }
@@ -48,10 +65,11 @@
 .footer-heading {
   color: var(--text-base) !important;
   font-family: Inter, sans-serif;
-  font-size: 1.1rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.5px;
-  margin-bottom: 1em;
+  line-height: 1.1;
+  letter-spacing: 0.12em;
+  margin: 0 0 1.15em;
   text-transform: uppercase;
 }
 
@@ -62,11 +80,14 @@
 }
 
 .footer-list li {
-  margin-bottom: 0.75em;
+  margin-bottom: 0.85em;
 }
 
 .footer-list a {
   color: var(--text-base);
+  font-family: Inter, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
   text-decoration: none;
   transition: color 0.2s ease-out;
 }
@@ -80,16 +101,16 @@
 
 .footer-sub {
   border-top: 1px solid #e2e8f0;
-  margin-top: 2em;
-  padding-top: 2em;
+  margin-top: 2.4em;
+  padding-top: 1.6em;
 }
 
 .footer-sub p {
   color: var(--text-base);
   font-family: Inter, sans-serif;
-  font-size: 0.74rem;
+  font-size: 0.68rem;
   font-weight: 600;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.1em;
   margin: 0;
   text-align: center;
   text-transform: uppercase;
@@ -97,7 +118,6 @@
 
 .new-footer .footer-list a {
   color: var(--text-base) !important;
-  font-weight: 500;
   text-decoration: none;
   transition: color 0.2s ease-out;
 }
@@ -111,10 +131,11 @@
 
 @media (width <= 768px) {
   .footer-main {
-    flex-direction: column;
+    gap: 2rem;
+    grid-template-columns: 1fr;
   }
 
   .footer-col {
-    padding: 1.5em 0;
+    padding: 0;
   }
 }

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,9 @@
 
 {{ partial "navigation.html" . }}
 
+{{ if not (hasPrefix .RelPermalink "/articles/") }}
 {{ partial "blog-breadcrumb.html" . }}
+{{ end }}
 
 {{"<!-- Start Blog Section -->" | safeHTML}}
 <section id="blog" class="section">

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -13,12 +13,10 @@
           </p>
           <div class="power-thesis__actions">
             <a
-              href="https://cal.com/christian-guzman/30-min-one-off-coaching"
+              href="/strategy-session/"
               class="power-thesis__btn power-thesis__btn--primary"
-              target="_blank"
-              rel="noopener"
             >
-              Book a free 30-min intro call
+              Book a free strategy session
             </a>
             <a href="/manifesto/" class="power-thesis__btn power-thesis__btn--ghost">
               View Manifesto

--- a/layouts/partials/author-box.html
+++ b/layouts/partials/author-box.html
@@ -9,7 +9,9 @@
 
       <div class="author-social">
         {{ range site.Params.footer.socialLinks }}
+          {{ if eq (lower .name) "linkedin" }}
           <a href="{{ .link | safeURL }}" target="_blank" rel="noopener">{{ .name }}</a>
+          {{ end }}
         {{ end }}
       </div>
     </div>

--- a/layouts/partials/blog.html
+++ b/layouts/partials/blog.html
@@ -18,7 +18,7 @@
 			{{ end }}
 
 			<div class="all-post text-center col-lg-12">
-				<a class="btn btn-main" href="{{ `blog/` | absLangURL }}">{{ i18n "viewAllPost" }}</a>
+				<a class="btn btn-main" href="{{ `articles/` | absLangURL }}">{{ i18n "viewAllPost" }}</a>
 			</div>
 		</div>
 	</div>

--- a/layouts/partials/single-breadcrumb.html
+++ b/layouts/partials/single-breadcrumb.html
@@ -2,7 +2,7 @@
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
       <li class="list-inline-item breadcrumb-item"><a href="/">Home</a></li>
-      <li class="list-inline-item breadcrumb-item"><a href="/blog">Blog</a></li>
+      <li class="list-inline-item breadcrumb-item"><a href="/articles/">Articles</a></li>
       <li class="list-inline-item breadcrumb-item active" aria-current="page">The Hidden Tax of the Brilliant Jerk</li>
     </ol>
   </nav>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -4,7 +4,16 @@
     <div class="footer-main">
 
       <div class="footer-col brand">
-        <a href="{{ site.Home.Permalink }}" class="footer-brand-link footer-brand-headline">Christian Guzman</a>
+        <a href="{{ site.Home.Permalink }}" class="footer-brand-link" aria-label="Christian Guzman Home">
+          <img
+            class="footer-avatar"
+            src="{{ with site.Params.authorbox.image }}{{ . | relURL }}{{ else }}{{ `images/avatar3.jpg` | relURL }}{{ end }}"
+            alt="Christian Guzman"
+            width="60"
+            height="60"
+          >
+          <span class="footer-brand-headline">Christian Guzman</span>
+        </a>
       </div>
 
       <div class="footer-col">
@@ -13,17 +22,17 @@
           <li><a href="{{ site.Home.Permalink }}" class="js-smooth-scroll">Home</a></li>
           <li><a href="/manifesto/" class="js-smooth-scroll">Manifesto</a></li>
           <li><a href="/articles/" class="js-smooth-scroll">Articles</a></li>
-          <li><a href="https://cal.com/christian-guzman/60min-one-off" target="_blank" class="js-smooth-scroll">Book a Call</a></li>
+          <li><a href="https://cal.com/christian-guzman/30-min-one-off-coaching" target="_blank" class="js-smooth-scroll">Strategy Session</a></li>
           
         </ul>
       </div>
 
       <div class="footer-col">
-        <h4 class="footer-heading">Social</h4>
+        <h4 class="footer-heading">Connect</h4>
         <ul class="footer-list social-links">
 
           {{ range site.Params.footer.socialLinks }}
-            {{ if ne (lower .name) "github" }}
+            {{ if eq (lower .name) "linkedin" }}
             <li><a href="{{ .link | safeURL }}" target="_blank" rel="noopener">{{ .name }}</a></li>
             {{ end }}
           {{ end }}
@@ -34,7 +43,7 @@
     </div>
 
     <div class="footer-sub">
-      <p>{{ site.Params.copyright | markdownify }}</p>
+      <p>&copy; 2026 Christian Guzman. All rights reserved.</p>
     </div>
 
   </div>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -11,9 +11,9 @@
         <h4 class="footer-heading">Navigation</h4>
         <ul class="footer-list">
           <li><a href="{{ site.Home.Permalink }}" class="js-smooth-scroll">Home</a></li>
-          <li><a href="/#about" class="js-smooth-scroll">About Me</a></li>
-          <li><a href="/blog" class="js-smooth-scroll">Latest Articles</a></li>
-          <li><a href="https://cal.com/christian-guzman/60min-one-off" target="_blank" class="js-smooth-scroll">Book Now!</a></li>
+          <li><a href="/manifesto/" class="js-smooth-scroll">Manifesto</a></li>
+          <li><a href="/articles/" class="js-smooth-scroll">Articles</a></li>
+          <li><a href="https://cal.com/christian-guzman/60min-one-off" target="_blank" class="js-smooth-scroll">Book a Call</a></li>
           
         </ul>
       </div>
@@ -23,7 +23,9 @@
         <ul class="footer-list social-links">
 
           {{ range site.Params.footer.socialLinks }}
+            {{ if ne (lower .name) "github" }}
             <li><a href="{{ .link | safeURL }}" target="_blank" rel="noopener">{{ .name }}</a></li>
+            {{ end }}
           {{ end }}
 
         </ul>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -22,7 +22,7 @@
           <li><a href="{{ site.Home.Permalink }}" class="js-smooth-scroll">Home</a></li>
           <li><a href="/manifesto/" class="js-smooth-scroll">Manifesto</a></li>
           <li><a href="/articles/" class="js-smooth-scroll">Articles</a></li>
-          <li><a href="https://cal.com/christian-guzman/30-min-one-off-coaching" target="_blank" class="js-smooth-scroll">Strategy Session</a></li>
+          <li><a href="/strategy-session/">Strategy Session</a></li>
           
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- update the homepage CTA label to 'Book a free strategy session'
- point the CTA to /strategy-session/ instead of Cal.com
- keep the manifesto CTA unchanged